### PR TITLE
Custom generator template feature 

### DIFF
--- a/package.json
+++ b/package.json
@@ -290,6 +290,11 @@
                     "default": "",
                     "markdownDescription": "The path of the `template` that has to be used when a folder is created"
                 },
+                "codepal.generatorTemplatePath": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "The path of the generator `template` that has to be used when stress testing is invoked"
+                },
                 "codepal.g++ CompilationFlags": {
                     "type": "string",
                     "default": "-std=c++14",

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -23,6 +23,7 @@ export const codepalConfigName = "codepal";
 export const enum CodepalConfig {
     compilationLanguage = "compilationLanguage",
     codeTemplatePath = "codeTemplatePath",
+    generatorTemplatePath = "generatorTemplatePath",
     codeforcesHandle = "codeforcesHandle",
     numberOfStressTestingTestCases = "numberOfStressTestingTestCases"
 }


### PR DESCRIPTION
Now the user can set the path to their custom generator template in settings. Whenever creating stress testing files that template will be used.