### PR TITLE
Add Haskell support and fix testcase parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A Visual Studio Code Extension to help **Codeforces** Users ***Code with Conveni
 - Java (compiler : javac)
 - Python
 - Kotlin
+- Haskell (compiler: ghc) [stress testing is not supported]
 - Note : You may add additional compilation flags through the codepal settings (example : -std=c++14) and also choose between python, python2 or python3 depending upon the python command you use on your system to run.
 
 # Operating Systems Supported

--- a/package.json
+++ b/package.json
@@ -339,27 +339,27 @@
             ],
             "editor/title": [
                 {
-                    "when": "resourceExtname == .kt || resourceExtname == .cpp || resourceExtname == .c || resourceExtname == .py || resourceExtname == .java",
+                    "when": "resourceExtname == .hs || resourceExtname == .kt || resourceExtname == .cpp || resourceExtname == .c || resourceExtname == .py || resourceExtname == .java",
                     "command": "codepal.runTestCases",
                     "group": "navigation"
                 },
                 {
-                    "when": "resourceExtname == .kt || resourceExtname == .cpp || resourceExtname == .c || resourceExtname == .py || resourceExtname == .java",
+                    "when": "resourceExtname == .hs || resourceExtname == .kt || resourceExtname == .cpp || resourceExtname == .c || resourceExtname == .py || resourceExtname == .java",
                     "command": "codepal.addTestCases",
                     "group": "navigation"
                 },
                 {
-                    "when": "resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.kt$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.cpp$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.c$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.py$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.java$/'",
+                    "when": "resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.hs$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.kt$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.cpp$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.c$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.py$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.java$/'",
                     "command": "codepal.submitProblem",
                     "group": "navigation"
                 },
                 {
-                    "when": "resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.kt$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.cpp$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.c$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.py$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.java$/'",
+                    "when": "resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.hs$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.kt$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.cpp$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.c$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.py$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.java$/'",
                     "command": "codepal.openProblemStatement",
                     "group": "navigation"
                 },
                 {
-                    "when": "resourceFilename != gen.kt && resourceFilename != brute.kt && resourceExtname == .kt || resourceFilename != gen.cpp && resourceFilename != brute.cpp && resourceExtname == .cpp || resourceFilename != gen.c && resourceFilename != brute.c && resourceExtname == .c || resourceFilename != gen.py && resourceFilename != brute.py && resourceExtname == .py || resourceFilename != gen.java && resourceFilename != brute.java && resourceExtname == .java",
+                    "when": "resourceFilename != gen.hs && resourceFilename != brute.hs && resourceExtname == .hs || resourceFilename != gen.kt && resourceFilename != brute.kt && resourceExtname == .kt || resourceFilename != gen.cpp && resourceFilename != brute.cpp && resourceExtname == .cpp || resourceFilename != gen.c && resourceFilename != brute.c && resourceExtname == .c || resourceFilename != gen.py && resourceFilename != brute.py && resourceExtname == .py || resourceFilename != gen.java && resourceFilename != brute.java && resourceExtname == .java",
                     "command": "codepal.stressTest",
                     "group": "navigation"
                 },
@@ -394,7 +394,8 @@
                         "python",
                         "python2",
                         "python3",
-                        "kotlin"
+                        "kotlin",
+                        "haskell"
                     ],
                     "markdownDescription": "Note : Incase of python please choose the python prefix you would generally use on your system to run"
                 },
@@ -438,6 +439,12 @@
                     "group": "language",
                     "markdownDescription": "Space separated additional compilation flags passed to kotlin"
                 },
+                "codepal.haskellCompilationFlags": {
+                    "type": "string",
+                    "default": "",
+                    "group": "language",
+                    "markdownDescription": "Space separated additional compilation flags passed to haskell"
+                },
                 "codepal.codeforcesHandle": {
                     "type": "string",
                     "default": "",
@@ -466,25 +473,25 @@
                 "command": "codepal.addTestCases",
                 "key": "ctrl+alt+a",
                 "mac": "cmd+alt+a",
-                "when": "resourceExtname == .kt || resourceExtname == .cpp || resourceExtname == .c || resourceExtname == .py || resourceExtname == .java"
+                "when": "resourceExtname == .hs || resourceExtname == .kt || resourceExtname == .cpp || resourceExtname == .c || resourceExtname == .py || resourceExtname == .java"
             },
             {
                 "command": "codepal.runTestCases",
                 "key": "ctrl+alt+r",
                 "mac": "cmd+alt+r",
-                "when": "resourceExtname == .kt || resourceExtname == .cpp || resourceExtname == .c || resourceExtname == .py || resourceExtname == .java"
+                "when": "resourceExtname == .hs || resourceExtname == .kt || resourceExtname == .cpp || resourceExtname == .c || resourceExtname == .py || resourceExtname == .java"
             },
             {
                 "command": "codepal.submitProblem",
                 "key": "ctrl+alt+s",
                 "mac": "cmd+alt+s",
-                "when": "resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.kt$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.cpp$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.c$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.py$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.java$/'"
+                "when": "resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.hs$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.kt$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.cpp$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.c$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.py$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.java$/'"
             },
             {
                 "command": "codepal.openProblemStatement",
                 "key": "ctrl+alt+o",
                 "mac": "cmd+alt+o",
-                "when": "resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.kt$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.cpp$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.c$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.py$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.java$/'"
+                "when": "resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.hs$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.kt$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.cpp$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.c$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.py$/' || resource =~ '/.*[A-Z][1-9]?_.*/[A-Z][1-9]?_.*\\.java$/'"
             },
             {
                 "command": "codepal.stopStressTesting",

--- a/src/features/folder_creation/problem_folder_creation.ts
+++ b/src/features/folder_creation/problem_folder_creation.ts
@@ -56,7 +56,9 @@ export const getFileExtension = (): string => {
         case CompilationLanguages.kotlin:
             fileExtension = 'kt';
             break;
-
+        case CompilationLanguages.haskell:
+            fileExtension = 'hs';
+            break;
         default:
             vscode.window.showErrorMessage("Language used is not supported");
             throw Error();

--- a/src/features/folder_creation/test_cases_fetch.ts
+++ b/src/features/folder_creation/test_cases_fetch.ts
@@ -35,8 +35,19 @@ const getInputOutput = async (problem: ProblemClass) => {
         let input: string[] = [];
         let output: string[] = [];
 
-        postTitleInput.each((i: Number, element: string) => {
-            input.push($(element).html().replace(/<br>/g, '\n'));
+        postTitleInput.each((i: Number, element: any) => {
+            let testBlock: string = "";
+
+            if (element.children.length > 1){ // there is mutli-test highlighting enabled 
+                element.children.forEach((testLine: any) => {
+                    testBlock += $(testLine).html() + '\n';
+                });;
+            }
+            else{
+                testBlock = $(element).html().replace(/<br>/g, '\n');
+            }
+            
+            input.push(testBlock);
         });
         postTitleOutput.each((i: Number, element: string) => {
             output.push($(element).html().replace(/<br>/g, '\n'));

--- a/src/features/run_test_cases/compile_solution.ts
+++ b/src/features/run_test_cases/compile_solution.ts
@@ -91,6 +91,17 @@ export const compileFile = async (
                 .get<String>(CompilationFlags.kotlin);
             compileCommand = `kotlinc "${solutionFilePath}" -include-runtime -d "${testsFolderPath}${outputFileName}.jar" ${compilationFlags}`;
             break;
+        case CompilationLanguages.haskell:
+            compilationFlags = vscode.workspace
+                .getConfiguration(codepalConfigName)
+                .get<String>(CompilationFlags.haskell);
+            if(platform() === "win32"){
+                compileCommand = `ghc -o "${testsFolderPath}${outputFileName}.exe" "${solutionFilePath}" ${compilationFlags}`;
+            }
+            else{
+                compileCommand = `ghc -o "${testsFolderPath}${outputFileName}.out" "${solutionFilePath}" ${compilationFlags}`;
+            }
+            break;
 
         default:
             vscode.window.showErrorMessage("Language used is not supported");

--- a/src/features/run_test_cases/run_solution.ts
+++ b/src/features/run_test_cases/run_solution.ts
@@ -37,6 +37,7 @@ export const runTestsWithTimeout = async (
     switch (compilationLanguage) {
         case CompilationLanguages.gcc:
         case CompilationLanguages.cpp:
+        case CompilationLanguages.haskell:
             if (os === OS.linuxMac) {
                 // Command for linux
                 executable = `${executableFileName}.out`;

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -54,7 +54,8 @@ export const enum CompilationLanguages {
     python = "python",
     python2 = "python2",
     python3 = "python3",
-    kotlin =  "kotlin"
+    kotlin =  "kotlin",
+    haskell = "haskell"
 
 }
 export const enum CompilationFlags {
@@ -63,6 +64,7 @@ export const enum CompilationFlags {
     java = "javaCompilationFlags",
     python = "pythonCompilationFlags",
     kotlin = "kotlinCompilationFlags",
+    haskell = "haskellCompilationFlags",
 }
 export const enum ContestsPhase {
     finished = "FINISHED",


### PR DESCRIPTION
- Added Haskell support for compiling and running test cases.
- The new codeforces test cases highlighting caused problems with the current method of parsing testcases. This commit fixes that.